### PR TITLE
Handle repo lookup failures, fix PackageURL.repository

### DIFF
--- a/Sources/ValidatorCore/Extensions/File.swift
+++ b/Sources/ValidatorCore/Extensions/File.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+
+extension URL {
+    func deletingGitExtension() -> URL {
+        pathExtension == "git"
+            ? deletingPathExtension()
+            : self
+    }
+}

--- a/Sources/ValidatorCore/PackageURL.swift
+++ b/Sources/ValidatorCore/PackageURL.swift
@@ -10,7 +10,7 @@ extension PackageURL {
     var absoluteString: String { rawValue.absoluteString }
     var host: String? { rawValue.host }
     var scheme: String? { rawValue.scheme }
-    var repository: String { rawValue.deletingPathExtension().lastPathComponent }
+    var repository: String { rawValue.deletingGitExtension().lastPathComponent }
     var owner: String { rawValue.deletingLastPathComponent().lastPathComponent }
 
     func addingGitExtension() -> Self {


### PR DESCRIPTION
There were actually two further problems lurking under the hood:

- PackageURL.repository stripped `https://github.com/stephencelis/SQLite.swift` down to `https://github.com/stephencelis/SQLite` which lead to a lookup failure

That in itself wouldn't necessarily be a problem, except that 

- the previous error handling is expecting a 404 and not a 200 + error JSON.

This error then bubbled up and led to a job failure after retries.