### PR TITLE
Support chunking

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -20,6 +20,15 @@
         }
       },
       {
+        "package": "swift-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-algorithms.git",
+        "state": {
+          "branch": null,
+          "revision": "b14b7f4c528c942f121c8b860b9410b2bf57825e",
+          "version": "1.0.0"
+        }
+      },
+      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
@@ -80,6 +89,15 @@
           "branch": null,
           "revision": "e7f5278a26442dc46783ba7e063643d524e414a0",
           "version": "1.11.3"
+        }
+      },
+      {
+        "package": "swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics",
+        "state": {
+          "branch": null,
+          "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",
+          "version": "1.0.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,7 @@ let package = Package(
         .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.3.0"),
         .package(name: "swift-tagged",
                  url: "https://github.com/pointfreeco/swift-tagged.git", from: "0.5.0"),
+        .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0")
     ],
     targets: [
         .target(name: "validator", dependencies: ["ValidatorCore"]),
@@ -36,7 +37,8 @@ let package = Package(
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 "ShellOut",
-                .product(name: "Tagged", package: "swift-tagged")
+                .product(name: "Tagged", package: "swift-tagged"),
+                .product(name: "Algorithms", package: "swift-algorithms"),
             ]),
         .testTarget(name: "ValidatorTests",
                     dependencies: ["ValidatorCore"],

--- a/Sources/ValidatorCore/Commands/CheckDependencies.swift
+++ b/Sources/ValidatorCore/Commands/CheckDependencies.swift
@@ -73,6 +73,9 @@ extension Validator {
             let inputURLs = try inputSource.packageURLs()
 
             print("Checking dependencies (\(limit ?? inputURLs.count) packages) ...")
+            if let chunk = chunk, let numberOfChunks = numberOfChunks {
+                print("Chunk \(chunk) of \(numberOfChunks)")
+            }
 
             let updated = try expandDependencies(inputURLs: inputURLs,
                                                  limit: limit,

--- a/Sources/ValidatorCore/Commands/CheckDependencies.swift
+++ b/Sources/ValidatorCore/Commands/CheckDependencies.swift
@@ -40,6 +40,12 @@ extension Validator {
         @Flag(name: .long, help: "check redirects of canonical package list")
         var usePackageList = false
 
+        @Option(name: .long, help: "index of chunk to process (0..<number-of-chunks)")
+        var chunk: Int?
+
+        @Option(name: .long, help: "number of chunks to split the package list into")
+        var numberOfChunks: Int?
+
         var inputSource: InputSource {
             switch (input, usePackageList, packageUrls.count) {
                 case (.some(let fname), false, 0):
@@ -70,6 +76,8 @@ extension Validator {
 
             let updated = try expandDependencies(inputURLs: inputURLs,
                                                  limit: limit,
+                                                 chunk: chunk,
+                                                 numberOfChunks: numberOfChunks,
                                                  retries: retries)
 
             if let path = output {
@@ -85,9 +93,12 @@ extension Validator {
 /// - Returns: complete list of package URLs, including the input set
 func expandDependencies(inputURLs: [PackageURL],
                         limit: Int? = nil,
+                        chunk: Int? = nil,
+                        numberOfChunks: Int? = nil,
                         retries: Int) throws -> [PackageURL] {
     try inputURLs
         .prefix(limit ?? inputURLs.count)
+        .chunk(index: chunk, of: numberOfChunks)
         .flatMap { packageURL -> [PackageURL] in
             do {
                 return try findDependencies(packageURL: packageURL,

--- a/Sources/ValidatorCore/Extensions/ArraySlice+ext.swift
+++ b/Sources/ValidatorCore/Extensions/ArraySlice+ext.swift
@@ -1,0 +1,29 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Algorithms
+
+
+extension ArraySlice {
+    func chunk(index: Int?, of maxChunks: Int?) -> Self {
+        guard let i = index, let n = maxChunks, n > 0 else {
+            return self
+        }
+        let chunkSize = Swift.max(1, Int((Double(count) / Double(n)).rounded(.up)))
+        let chunks = chunks(ofCount: chunkSize)
+        return chunks[chunks.index(chunks.startIndex, offsetBy: i)]
+    }
+}
+
+

--- a/Tests/ValidatorTests/ValidatorTests.swift
+++ b/Tests/ValidatorTests/ValidatorTests.swift
@@ -219,6 +219,31 @@ final class ValidatorTests: XCTestCase {
         XCTAssertEqual(pkg.name, "Bow OpenAPI")
     }
 
+    func test_ArraySlice_chunk() throws {
+        do {
+            XCTAssertEqual(Array(0..<8)[...].chunk(index: 0, of: 3), [0, 1, 2])
+            XCTAssertEqual(Array(0..<8)[...].chunk(index: 1, of: 3), [3, 4, 5])
+            XCTAssertEqual(Array(0..<8)[...].chunk(index: 2, of: 3), [6, 7])
+        }
+        do {
+            XCTAssertEqual(Array(1..<8)[...].chunk(index: 0, of: 3), [1, 2, 3])
+            XCTAssertEqual(Array(1..<8)[...].chunk(index: 1, of: 3), [4, 5, 6])
+            XCTAssertEqual(Array(1..<8)[...].chunk(index: 2, of: 3), [7])
+        }
+        do {
+            XCTAssertEqual(Array(0..<2)[...].chunk(index: 0, of: 0), [0, 1])
+        }
+        do {
+            XCTAssertEqual(Array(0..<2)[...].chunk(index: nil, of: 0), [0, 1])
+        }
+        do {
+            XCTAssertEqual(Array(0..<2)[...].chunk(index: 0, of: nil), [0, 1])
+        }
+        do {
+            XCTAssertEqual(Array(0..<2)[...].chunk(index: nil, of: nil), [0, 1])
+        }
+    }
+
 }
 
 

--- a/run-dependencies.sh
+++ b/run-dependencies.sh
@@ -14,9 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#validator="xcrun swift run validator"
 validator="./validator"
 
+# log the first 10 packages so we can compare the chunking
+echo "Head of packages.json:"
+curl -s https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/packages.json | head -11
+echo "..."
+echo
 
-$validator check-dependencies --use-package-list -o packages.json -l 10
+$validator check-dependencies --use-package-list -o packages.json -l 10 --chunk 1 --number-of-chunks 3
 cat packages.json


### PR DESCRIPTION
This adds support for chunking the package list during dependency checking:

```
  --chunk <chunk>         index of chunk to process (0..<number-of-chunks)
  --number-of-chunks <number-of-chunks>
                          number of chunks to split the package list into
```

such that we can set up a number of consecutive jobs:

```
./validator check-dependencies --use-package-list -o packages.json --chunk 0 --number-of-chunks 3
```

which go through the full list sequentially.