### PR TITLE
Revert "Merge pull request #20 from SwiftPackageIndex/support-chunking"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,9 @@ import PackageDescription
 let package = Package(
     name: "validator",
     platforms: [.macOS(.v10_15)],
+    products: [
+      .executable(name: "validator", targets: ["validator"])  
+    ],
     dependencies: [
         .package(name: "async-http-client",
                  url: "https://github.com/swift-server/async-http-client.git", from: "1.2.0"),

--- a/Sources/ValidatorCore/Commands/CheckRedirects.swift
+++ b/Sources/ValidatorCore/Commands/CheckRedirects.swift
@@ -38,12 +38,6 @@ extension Validator {
         @Flag(name: .long, help: "enable detailed logging")
         var verbose = false
 
-        @Option(name: .long, help: "index of chunk to process (0..<number-of-chunks)")
-        var chunk: Int?
-
-        @Option(name: .long, help: "number of chunks to split the package list into")
-        var numberOfChunks: Int?
-
         var inputSource: InputSource {
             switch (input, usePackageList, packageUrls.count) {
                 case (.some(let fname), false, 0):
@@ -113,7 +107,6 @@ extension Validator {
             var normalized = Set(inputURLs.map { $0.normalized() })
             let updated = try inputURLs
                 .prefix(prefix)
-                .chunk(index: chunk, of: numberOfChunks)
                 .enumerated()
                 .compactMap { (index, packageURL) in
                     try resolvePackageRedirects(eventLoop: elg.next(), for: packageURL)

--- a/run-redirects.sh
+++ b/run-redirects.sh
@@ -14,13 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#validator="xcrun swift run validator"
 validator="./validator"
 
-# log the first 10 packages so we can compare the chunking
-echo "Head of packages.json:"
-curl -s https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/packages.json | head -11
-echo "..."
-echo
 
-$validator check-redirects --use-package-list -o packages.json -l 10 --chunk 1 --number-of-chunks 3
+#curl -O "https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/packages.json"
+
+$validator check-redirects --use-package-list -o packages.json -l 10
 cat packages.json


### PR DESCRIPTION
We can't actually chunk the redirect check, because it'll truncate the output list. (Nor do we need to: it completes in ~30-40 mins, the reason it took so long in the last test was because I'd accidentally stripped out the GITHUB_TOKEN env variable in the update.)