### PR TITLE
Save and load dump cache between chunks

### DIFF
--- a/Sources/ValidatorCore/Commands/CheckDependencies.swift
+++ b/Sources/ValidatorCore/Commands/CheckDependencies.swift
@@ -73,6 +73,10 @@ extension Validator {
                 print("Warning: Using anonymous authentication -- you will quickly run into rate limiting issues\n")
             }
 
+            // Load package dump cache from previous chunk
+            Package.loadPackageDumpCache()
+            print("Cache loaded (\(Package.packageDumpCache.data.count) entries)")
+
             let inputURLs = try inputSource.packageURLs()
 
             print("Checking dependencies (\(limit ?? inputURLs.count) packages) ...")
@@ -89,6 +93,9 @@ extension Validator {
             if let path = output {
                 try Current.fileManager.saveList(updated, path: path)
             }
+
+            // Save out package dump cache for subsequent chunks
+            try Package.savePackageDumpCache()
         }
     }
 }

--- a/Sources/ValidatorCore/FileManager.swift
+++ b/Sources/ValidatorCore/FileManager.swift
@@ -16,6 +16,7 @@ import Foundation
 
 
 struct FileManager {
+    var contents: (_ atPath: String) -> Data?
     var createDirectory: (_ path: String,
                           _ withIntermediateDirectories: Bool,
                           _ attributes: [FileAttributeKey : Any]?) throws -> Void
@@ -25,25 +26,30 @@ struct FileManager {
     var fileExists: (_ path: String) -> Bool
     var removeItem: (_ path: String) throws -> Void
     var temporaryDirectory: () -> URL
+    var write: (_ contents: Data, _ toPath: String) throws -> Void
 }
 
 
 extension FileManager {
     static let live: Self = .init(
+        contents: Foundation.FileManager.default.contents(atPath:),
         createDirectory: Foundation.FileManager.default
             .createDirectory(atPath:withIntermediateDirectories:attributes:),
         createFile: Foundation.FileManager.default.createFile(atPath:contents:attributes:),
         fileExists: Foundation.FileManager.default.fileExists(atPath:),
         removeItem: Foundation.FileManager.default.removeItem(atPath:),
-        temporaryDirectory: { Foundation.FileManager.default.temporaryDirectory }
+        temporaryDirectory: { Foundation.FileManager.default.temporaryDirectory },
+        write: { data, path in try data.write(to: URL(fileURLWithPath: path)) }
     )
 
     static let mock: Self = .init(
+        contents: { _ in nil },
         createDirectory: { _, _, _ in },
         createFile: { _, _, _ in true },
         fileExists: { _ in true },
         removeItem: { _ in },
-        temporaryDirectory: { fatalError("not implemented") }
+        temporaryDirectory: { fatalError("not implemented") },
+        write: { _, _ in }
     )
 }
 

--- a/Sources/ValidatorCore/Package.swift
+++ b/Sources/ValidatorCore/Package.swift
@@ -53,6 +53,10 @@ extension Package {
 
     static var packageDumpCache = Cache<Package>()
 
+    static var cacheFilename: String { ".packageDumpCache" }
+    static func loadPackageDumpCache() { packageDumpCache = .load(from: cacheFilename) }
+    static func savePackageDumpCache() throws { try packageDumpCache.save(to: cacheFilename) }
+
     static func decode(from manifestURL: ManifestURL) throws -> Package {
         if let cached = packageDumpCache[Cache.Key(string: manifestURL.rawValue.absoluteString)] {
             return cached

--- a/Tests/ValidatorTests/CacheTests.swift
+++ b/Tests/ValidatorTests/CacheTests.swift
@@ -1,0 +1,42 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import ValidatorCore
+
+
+final class CacheTests: XCTestCase {
+
+    func test_load() throws {
+        // setup
+        let cacheFilename = "cache"
+        Current.fileManager.fileExists = { _ in true }
+        Current.fileManager.contents = { fname in
+            if fname == cacheFilename {
+                let cache = [ Cache<Int>.Key(string: "0"): try! JSONEncoder().encode(0) ]
+                return try? JSONEncoder().encode(cache)
+            } else {
+                return nil
+            }
+        }
+
+        // MUT
+        let cache = Cache<Int>.load(from: cacheFilename)
+
+        // validate
+        XCTAssertEqual(cache[.init(string: "0")], 0)
+    }
+
+}


### PR DESCRIPTION
With 10 chunks our package dump cache is pretty useless as it needs to be build up pretty much in full for each run, making them take much longer (because they use up more API calls).