### PR TITLE
Issue 2551 check dependencies failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .swiftpm
 packages.json
 .vscode/
+.DS_Store

--- a/Tests/ValidatorTests/Fixtures/Issue2551.json
+++ b/Tests/ValidatorTests/Fixtures/Issue2551.json
@@ -1,0 +1,661 @@
+{
+  "cLanguageStandard" : null,
+  "cxxLanguageStandard" : null,
+  "dependencies" : [
+    {
+      "sourceControl" : [
+        {
+          "identity" : "ink",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/JohnSundell/Ink.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "range" : [
+              {
+                "lowerBound" : "0.5.1",
+                "upperBound" : "1.0.0"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "plot",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/daveverwer/Plot.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "branch" : [
+              "sitemapindex"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "swiftprometheus",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/MrLotU/SwiftPrometheus.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "range" : [
+              {
+                "lowerBound" : "1.0.0-alpha",
+                "upperBound" : "2.0.0"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "dependencyresolution",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/SwiftPackageIndex/DependencyResolution"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "range" : [
+              {
+                "lowerBound" : "1.0.0",
+                "upperBound" : "2.0.0"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "spimanifest",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/SwiftPackageIndex/SPIManifest.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "range" : [
+              {
+                "lowerBound" : "1.0.0",
+                "upperBound" : "2.0.0"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "semanticversion",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/SwiftPackageIndex/SemanticVersion"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "range" : [
+              {
+                "lowerBound" : "0.3.0",
+                "upperBound" : "1.0.0"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "shellout",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/SwiftPackageIndex/ShellOut.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "revision" : [
+              "db112a2104eae7fa8412ea80210d0f60b89a377e"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "swift-package-manager",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/apple/swift-package-manager.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "branch" : [
+              "release/5.9"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "vaportoopenapi",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/dankinsoid/VaporToOpenAPI.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "range" : [
+              {
+                "lowerBound" : "4.0.0",
+                "upperBound" : "5.0.0"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "swift-custom-dump",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/pointfreeco/swift-custom-dump.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "range" : [
+              {
+                "lowerBound" : "0.10.0",
+                "upperBound" : "1.0.0"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "swift-parsing",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/pointfreeco/swift-parsing.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "range" : [
+              {
+                "lowerBound" : "0.12.0",
+                "upperBound" : "1.0.0"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "swift-snapshot-testing",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/pointfreeco/swift-snapshot-testing.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "range" : [
+              {
+                "lowerBound" : "1.11.1",
+                "upperBound" : "2.0.0"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "swiftsoup",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/scinfu/SwiftSoup.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "range" : [
+              {
+                "lowerBound" : "2.3.2",
+                "upperBound" : "3.0.0"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "soto",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/soto-project/soto.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "range" : [
+              {
+                "lowerBound" : "6.0.0",
+                "upperBound" : "7.0.0"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "fluent-postgres-driver",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/vapor/fluent-postgres-driver.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "range" : [
+              {
+                "lowerBound" : "2.0.0",
+                "upperBound" : "3.0.0"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "fluent",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/vapor/fluent.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "range" : [
+              {
+                "lowerBound" : "4.0.0",
+                "upperBound" : "5.0.0"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "sourceControl" : [
+        {
+          "identity" : "vapor",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/vapor/vapor.git"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "range" : [
+              {
+                "lowerBound" : "4.0.0",
+                "upperBound" : "5.0.0"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "name" : "SPI-Server",
+  "packageKind" : {
+    "root" : [
+      "/private/var/folders/nk/tlpts6bs799038htr6rx1xnc0000gn/T/FA998C18-A533-4F2F-8E09-64429F689D8B"
+    ]
+  },
+  "pkgConfig" : null,
+  "platforms" : [
+    {
+      "options" : [
+
+      ],
+      "platformName" : "macos",
+      "version" : "12.0"
+    }
+  ],
+  "products" : [
+
+  ],
+  "providers" : null,
+  "swiftLanguageVersions" : [
+    "5"
+  ],
+  "targets" : [
+    {
+      "dependencies" : [
+        {
+          "byName" : [
+            "App",
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "Run",
+      "packageAccess" : false,
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "executable"
+    },
+    {
+      "dependencies" : [
+        {
+          "byName" : [
+            "Ink",
+            null
+          ]
+        },
+        {
+          "byName" : [
+            "Plot",
+            null
+          ]
+        },
+        {
+          "byName" : [
+            "S3Store",
+            null
+          ]
+        },
+        {
+          "byName" : [
+            "SPIManifest",
+            null
+          ]
+        },
+        {
+          "byName" : [
+            "SemanticVersion",
+            null
+          ]
+        },
+        {
+          "byName" : [
+            "SwiftPrometheus",
+            null
+          ]
+        },
+        {
+          "byName" : [
+            "SwiftSoup",
+            null
+          ]
+        },
+        {
+          "product" : [
+            "CustomDump",
+            "swift-custom-dump",
+            null,
+            null
+          ]
+        },
+        {
+          "product" : [
+            "DependencyResolution",
+            "DependencyResolution",
+            null,
+            null
+          ]
+        },
+        {
+          "product" : [
+            "Fluent",
+            "fluent",
+            null,
+            null
+          ]
+        },
+        {
+          "product" : [
+            "FluentPostgresDriver",
+            "fluent-postgres-driver",
+            null,
+            null
+          ]
+        },
+        {
+          "product" : [
+            "Parsing",
+            "swift-parsing",
+            null,
+            null
+          ]
+        },
+        {
+          "product" : [
+            "ShellOut",
+            "ShellOut",
+            null,
+            null
+          ]
+        },
+        {
+          "product" : [
+            "SwiftPMDataModel-auto",
+            "swift-package-manager",
+            null,
+            null
+          ]
+        },
+        {
+          "product" : [
+            "SwiftPMPackageCollections",
+            "swift-package-manager",
+            null,
+            null
+          ]
+        },
+        {
+          "product" : [
+            "Vapor",
+            "vapor",
+            null,
+            null
+          ]
+        },
+        {
+          "product" : [
+            "VaporToOpenAPI",
+            "VaporToOpenAPI",
+            null,
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "App",
+      "packageAccess" : false,
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "regular"
+    },
+    {
+      "dependencies" : [
+        {
+          "product" : [
+            "SotoS3",
+            "soto",
+            null,
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "S3Store",
+      "packageAccess" : false,
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "regular"
+    },
+    {
+      "dependencies" : [
+        {
+          "product" : [
+            "SnapshotTesting",
+            "swift-snapshot-testing",
+            null,
+            null
+          ]
+        },
+        {
+          "product" : [
+            "XCTVapor",
+            "vapor",
+            null,
+            null
+          ]
+        },
+        {
+          "target" : [
+            "App",
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+        "__Snapshots__",
+        "Fixtures"
+      ],
+      "name" : "AppTests",
+      "packageAccess" : false,
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "test"
+    },
+    {
+      "dependencies" : [
+        {
+          "target" : [
+            "S3Store",
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "S3StoreTests",
+      "packageAccess" : false,
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "test"
+    }
+  ],
+  "toolsVersion" : {
+    "_version" : "5.8.0"
+  }
+}

--- a/Tests/ValidatorTests/RegressionTests.swift
+++ b/Tests/ValidatorTests/RegressionTests.swift
@@ -76,4 +76,24 @@ final class RegressionTests: XCTestCase {
         XCTAssertEqual(pkg.name, "Bow OpenAPI")
     }
 
+    func test_issue_2551_DecodingError() throws {
+        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2551
+
+        //        try Validator.CheckDependencies.run(inputSource: .packageURLs([
+        //            .init(argument: "https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server")!
+        //        ]), retries: 0)
+
+        // setup
+        let data = try fixtureData(for: "Issue2551.json")
+
+        // MUT
+        let pkg = try JSONDecoder().decode(Package.self, from: data)
+
+        // validate
+        XCTAssertEqual(pkg.name, "SPI-Server")
+        XCTAssertEqual(pkg.dependencies.count, 17)
+        XCTAssertEqual(pkg.dependencies.first?.firstRemote,
+                       .init(rawValue: URL(string: "https://github.com/JohnSundell/Ink.git")!))
+    }
+
 }

--- a/Tests/ValidatorTests/RegressionTests.swift
+++ b/Tests/ValidatorTests/RegressionTests.swift
@@ -1,0 +1,79 @@
+//
+//  RegressionTests.swift
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import ValidatorCore
+
+
+final class RegressionTests: XCTestCase {
+
+    func test_issue_917() throws {
+        // Ensure we don't change existing package's capitalisation
+        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/917
+        // setup
+        let p1 = PackageURL(argument:
+                                "https://github.com/1fr3dg/ResourcePackage.git")!
+        let dep = PackageURL(argument:
+                                "https://github.com/1Fr3dG/SimpleEncrypter.git")!
+        let p2 = PackageURL(argument:
+                                "https://github.com/1fr3dg/SimpleEncrypter.git")!
+        Current.decodeManifest = { url in
+            url == .init("https://raw.githubusercontent.com/1fr3dg/ResourcePackage/main/Package.swift")
+            ? .mock(dependencyURLs: [dep])
+            : .mock(dependencyURLs: [])
+        }
+
+        // MUT
+        let urls = expandDependencies(inputURLs: [p1, p2], retries: 0)
+
+        // validate
+        XCTAssertEqual(urls, [p1, p2])
+    }
+
+    func test_issue_1449_DecodingError() throws {
+        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1449
+        // also
+        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1461
+
+        for toolsVersion in ["5.1", "5.2", "5.3", "5.4", "5.5"] {
+            // setup
+            let data = try fixtureData(for: "Issue1449-\(toolsVersion).json")
+
+            // MUT
+            let pkg = try JSONDecoder().decode(Package.self, from: data)
+
+            // validate
+            XCTAssertEqual(pkg.name, "ValidatorTest", "failed for: \(toolsVersion)")
+            XCTAssertEqual(pkg.toolsVersion?._version, "\(toolsVersion).0",
+                           "failed for: \(toolsVersion)")
+        }
+    }
+
+    func test_issue_1618_DecodingError() throws {
+        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1618
+
+        // setup
+        let data = try fixtureData(for: "Issue1618.json")
+
+        // MUT
+        let pkg = try JSONDecoder().decode(Package.self, from: data)
+
+        // validate
+        XCTAssertEqual(pkg.name, "Bow OpenAPI")
+    }
+
+}

--- a/Tests/ValidatorTests/Utils.swift
+++ b/Tests/ValidatorTests/Utils.swift
@@ -68,7 +68,7 @@ extension Package.ManifestURL {
 extension Package.Dependency {
     init(location: PackageURL) {
         self.init(sourceControl: [
-            .init(location: .init(remote: [location]))
+            .init(location: .init(remote: [.init(packageURL: location)]))
         ])
     }
 }

--- a/Tests/ValidatorTests/Utils.swift
+++ b/Tests/ValidatorTests/Utils.swift
@@ -30,3 +30,45 @@ func fixturesDirectory(path: String = #file) -> URL {
     let testsDir = url.deletingLastPathComponent()
     return testsDir.appendingPathComponent("Fixtures")
 }
+
+
+// MARK: - Extension helpers
+
+@testable import ValidatorCore
+
+extension Package {
+    static func mock(dependencyURLs: [PackageURL]) -> Self {
+        .init(name: "",
+              products: [.mock],
+              dependencies: dependencyURLs.map { .init(location: $0) } )
+    }
+}
+
+
+extension Package.Product {
+    static let mock: Self = .init(name: "product")
+}
+
+
+extension Array where Element == String {
+    var asURLs: [PackageURL] {
+        compactMap(URL.init(string:))
+            .map(PackageURL.init(rawValue:))
+    }
+}
+
+
+extension Package.ManifestURL {
+    init(_ urlString: String) {
+        self.init(rawValue: URL(string: urlString)!)
+    }
+}
+
+
+extension Package.Dependency {
+    init(location: PackageURL) {
+        self.init(sourceControl: [
+            .init(location: .init(remote: [location]))
+        ])
+    }
+}


### PR DESCRIPTION
I believe this changed when we adopted Swift 5.9 for validation. There's been a subtle format change in the package dump json from

```json
          "location" : {
            "remote" : [
              "https://github.com/apple/swift-argument-parser"
            ]
          },
```

to

```json
          "location" : {
            "remote" : [
              {
                "urlString" : "https://github.com/JohnSundell/Ink.git"
              }
            ]
          },
```

which tripped us up. We're now supporting both versions.

I've made a note to try and detect changes like this somehow between Swift versions.

Fixes https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2551