### PR TITLE
Fix sorting

### DIFF
--- a/Sources/ValidatorCore/Commands/ApplyDenyList.swift
+++ b/Sources/ValidatorCore/Commands/ApplyDenyList.swift
@@ -66,7 +66,7 @@ extension Validator {
             return Array(
                 Set(packageList.map(CaseInsensitivePackageURL.init))
                     .subtracting(Set(denyList.map(CaseInsensitivePackageURL.init)))
-            ).map(\.url).sorted { $0.absoluteString < $1.absoluteString }
+            ).map(\.url).sorted { $0.absoluteString.lowercased() < $1.absoluteString.lowercased() }
         }
 
         var packageListEncoder: JSONEncoder {


### PR DESCRIPTION
I noticed this (which is what we discussed the other day) while debugging an unrelated problem with our nightly: `apply-deny-list` changes the sorting of the original package list when it subtracts the deny list.

Here's the before and after of a snippet:

```
packages.json before deny list
[
  ...
  "https://github.com/swift-server-community/APNSwift.git",
  "https://github.com/swift-server-community/mqtt-nio.git",
  "https://github.com/swift-server/async-http-client.git",
  "https://github.com/swift-server/RediStack.git",
  "https://github.com/swift-server/security.git",
  ...
]
```

```
packages.json after deny list
[
  ...
  "https://github.com/swift-server-community/APNSwift.git",
  "https://github.com/swift-server-community/mqtt-nio.git",
  "https://github.com/swift-server/RediStack.git",
  "https://github.com/swift-server/async-http-client.git",
  "https://github.com/swift-server/security.git",
  ...
]
```

Notice how `async-http-client.git` and `RediStack.git` are trading places.

This is likely the source of the big delta we've been seeing.