### PR TITLE
CheckDependencies2 → CheckDependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,11 @@ name: CI
 on:
     workflow_dispatch:
     push:
-      # branches: [ main ]
-    pull_request:
-      branches: [ main ]
 
 env:
   DEVELOPER_DIR: /Applications/Xcode_13.2.1.app
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  SPI_API_TOKEN: ${{ secrets.SPI_API_TOKEN }}
 
 jobs:
   test-validator-Linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
         run: |
           swift build
 
+      - name: Install curl
+        run: apt-get update && apt-get install -y curl
+
       - name: Check redirects
         run: ./check-redirects.sh
 

--- a/Sources/ValidatorCore/Commands/CheckDependencies.swift
+++ b/Sources/ValidatorCore/Commands/CheckDependencies.swift
@@ -29,6 +29,9 @@ public struct CheckDependencies: AsyncParsableCommand {
     @Option(name: .shortAndLong)
     var limit: Int = .max
 
+    @Option(name: .shortAndLong)
+    var maxCheck: Int = .max
+
     @Option(name: .shortAndLong, help: "save changes to output file")
     var output: String?
 
@@ -58,6 +61,7 @@ public struct CheckDependencies: AsyncParsableCommand {
         var newPackages = UniqueCanonicalPackageURLs()
         for (idx, dep) in missing
             .sorted(by: { $0.packageURL.absoluteString < $1.packageURL.absoluteString })
+            .prefix(maxCheck)
             .enumerated() {
             if idx % 10 == 0 {
                 print("Progress:", idx, "/", missing.count)

--- a/Sources/ValidatorCore/Commands/CheckDependencies.swift
+++ b/Sources/ValidatorCore/Commands/CheckDependencies.swift
@@ -19,7 +19,7 @@ import AsyncHTTPClient
 import CanonicalPackageURL
 
 
-public struct CheckDependencies2: AsyncParsableCommand {
+public struct CheckDependencies: AsyncParsableCommand {
     @Option(name: .long)
     var apiBaseURL: String = "https://swiftpackageindex.com"
 
@@ -124,7 +124,7 @@ public struct CheckDependencies2: AsyncParsableCommand {
 }
 
 
-extension CheckDependencies2 {
+extension CheckDependencies {
     var inputSource: InputSource {
         switch (input, packageUrls.count) {
             case (.some(let fname), 0):

--- a/Sources/ValidatorCore/Commands/Validator.swift
+++ b/Sources/ValidatorCore/Commands/Validator.swift
@@ -18,7 +18,7 @@ import ArgumentParser
 public struct Validator: AsyncParsableCommand {
     public static var configuration = CommandConfiguration(
         abstract: "SPI Validator",
-        subcommands: [CheckDependencies2.self,
+        subcommands: [CheckDependencies.self,
                       CheckRedirects.self,
                       MergeLists.self,
                       ApplyDenyList.self,

--- a/Tests/ValidatorTests/CheckDependencies2Tests.swift
+++ b/Tests/ValidatorTests/CheckDependencies2Tests.swift
@@ -21,7 +21,7 @@ import NIO
 
 
 final class CheckDependencies2Tests: XCTestCase {
-    var check = CheckDependencies2()
+    var check = CheckDependencies()
 
     override func setUp() {
         super.setUp()

--- a/check-dependencies.sh
+++ b/check-dependencies.sh
@@ -22,4 +22,7 @@ curl -s https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/pac
 echo "..."
 echo
 
-$validator check-dependencies --use-package-list -o packages.json -l 10 --chunk 1 --number-of-chunks 3
+$validator check-dependencies \
+    --spi-api-token "$SPI_API_TOKEN" \
+    -i packages.json -o packages.json \
+    --max-check 1


### PR DESCRIPTION
CI was actually failing and didn't block the merge due to misconfiguration: https://github.com/SwiftPackageIndex/PackageList-Validator/actions/runs/7420472744