### PR TITLE
HTTPClient based redirect check

### DIFF
--- a/Sources/ValidatorCore/Commands/CheckDependencies.swift
+++ b/Sources/ValidatorCore/Commands/CheckDependencies.swift
@@ -69,7 +69,7 @@ public struct CheckDependencies: AsyncParsableCommand {
             
             // resolve redirects
             print("Processing:", dep.packageURL, "...")
-            guard let resolved = await Current.resolvePackageRedirects(dep.packageURL).url else {
+            guard let resolved = try? await Current.resolvePackageRedirects(dep.packageURL).url else {
                 // TODO: consider adding retry for some errors
                 print("  ... ⛔ redirect resolution returned nil")
                 continue

--- a/Sources/ValidatorCore/Environment.swift
+++ b/Sources/ValidatorCore/Environment.swift
@@ -25,7 +25,7 @@ struct Environment {
     var fetchDependencies: (_ api: SwiftPackageIndexAPI) async throws -> [SwiftPackageIndexAPI.PackageRecord]
     var fetchRepository: (_ client: HTTPClient, _ url: PackageURL) async throws -> Github.Repository
     var githubToken: () -> String?
-    var resolvePackageRedirects: (PackageURL) async -> Redirect
+    var resolvePackageRedirects: (PackageURL) async throws -> Redirect
     var shell: Shell
 }
 

--- a/Sources/ValidatorCore/RedirectFollower.swift
+++ b/Sources/ValidatorCore/RedirectFollower.swift
@@ -102,12 +102,11 @@ func resolveRedirects(eventLoop: EventLoop, for url: PackageURL) -> EventLoopFut
 }
 
 
-func resolveRedirects(for url: PackageURL) async -> Redirect {
-    await withCheckedContinuation { continuation in
-        let _ = RedirectFollower(initialURL: url) {
-            continuation.resume(returning: $0)
-        }
-    }
+func resolveRedirects(for url: PackageURL) async throws -> Redirect {
+    let client = HTTPClient(eventLoopGroupProvider: .singleton,
+                                configuration: .init(redirectConfiguration: .disallow))
+    defer { try? client.syncShutdown() }
+    return try await resolveRedirects(client: client, for: url).get()
 }
 
 

--- a/Sources/ValidatorCore/RedirectFollower.swift
+++ b/Sources/ValidatorCore/RedirectFollower.swift
@@ -51,7 +51,7 @@ func resolveRedirects(for url: PackageURL) async throws -> Redirect {
 }
 
 
-func resolveRedirects(client: HTTPClient, for url: PackageURL) -> EventLoopFuture<Redirect> {
+private func resolveRedirects(client: HTTPClient, for url: PackageURL) -> EventLoopFuture<Redirect> {
     var lastResult = Redirect.initial(url)
     var hopCount = 0
     let maxHops = 10
@@ -127,10 +127,6 @@ func resolveRedirects(client: HTTPClient, for url: PackageURL) -> EventLoopFutur
 
 
 /// Resolve redirects for package urls. In particular, this strips the `.git` extension from the test url, because it would always lead to a redirect. It also normalizes the output to always have a `.git` extension.
-/// - Parameters:
-///   - eventLoop: EventLoop
-///   - url: url to test
-///   - timeout: request timeout
 /// - Returns: `Redirect`
 func resolvePackageRedirects(client: HTTPClient, for url: PackageURL) -> EventLoopFuture<Redirect> {
     resolveRedirects(client: client, for: url.deletingGitExtension())

--- a/Sources/ValidatorCore/RedirectFollower.swift
+++ b/Sources/ValidatorCore/RedirectFollower.swift
@@ -47,7 +47,13 @@ func resolveRedirects(for url: PackageURL) async throws -> Redirect {
     let client = HTTPClient(eventLoopGroupProvider: .singleton,
                             configuration: .init(redirectConfiguration: .disallow))
     defer { try? client.syncShutdown() }
-    return try await resolveRedirects(client: client, for: url).get()
+    let res = try await resolveRedirects(client: client, for: url.deletingGitExtension()).get()
+    switch res {
+        case .initial, .notFound, .error, .unauthorized, .rateLimited:
+            return res
+        case .redirected(to: let newURL):
+            return .redirected(to: newURL.appendingGitExtension())
+    }
 }
 
 

--- a/Sources/ValidatorCore/RedirectFollower.swift
+++ b/Sources/ValidatorCore/RedirectFollower.swift
@@ -160,7 +160,6 @@ func resolveRedirects(client: HTTPClient, for url: PackageURL) -> EventLoopFutur
     let maxHops = 10
 
     func _resolveRedirects(client: HTTPClient, for url: PackageURL) -> EventLoopFuture<Redirect> {
-        print("Resolving:", url)
         do {
             var request = try HTTPClient.Request(url: url.rawValue, method: .HEAD, headers: .init([
                 ("User-Agent", "SPI-Validator")
@@ -170,7 +169,6 @@ func resolveRedirects(client: HTTPClient, for url: PackageURL) -> EventLoopFutur
             }
             return client.execute(request: request)
                 .flatMap { response in
-                    print("status:", response.status.code)
                     let el = client.eventLoopGroup.next()
                     switch response.status.code {
                         case 200...299:


### PR DESCRIPTION
More consolidation & cleanup.

We had two different ways of checking for redirects, a HTTPClient based one and a URLSession based one. This moves to a single one and starts the transition towards async/await conversion.

This is ready for review but I'm leaving it in "draft" to let at least one more nightly run with all of today's earlier changes before we deploy this (which a merge does automatically).